### PR TITLE
feat: display process status in the scripts panel

### DIFF
--- a/src/executors/streaming.rs
+++ b/src/executors/streaming.rs
@@ -1,4 +1,5 @@
 use crate::types::Config;
+use bevy::log::info;
 use bevy::prelude::*;
 use crossbeam_channel::{bounded, Receiver, Sender};
 use serde::Deserialize;
@@ -260,7 +261,19 @@ impl StreamManager {
             thread::spawn(move || {
                 for line in stdout_reader.lines() {
                     if let Ok(line) = line {
-                        info!("Python output: {}", line);
+                        info!("[py stdout] {}", line);
+                    }
+                }
+            });
+        }
+
+        // Also capture stderr if present
+        if let Some(stderr) = child.stderr.take() {
+            let stderr_reader = BufReader::new(stderr);
+            thread::spawn(move || {
+                for line in stderr_reader.lines() {
+                    if let Ok(line) = line {
+                        warn!("[py stderr] {}", line);
                     }
                 }
             });

--- a/src/executors/streaming.rs
+++ b/src/executors/streaming.rs
@@ -37,7 +37,7 @@ impl StreamPoint {
 #[derive(Debug, Clone, PartialEq)]
 pub enum ProcessStatus {
     Running,
-    Failed(String), // Contains error message
+    Failed(Option<i32>), // Exit code
     Finished,
 }
 
@@ -319,10 +319,7 @@ pub fn check_process_status(stream_manager: ResMut<StreamManager>) {
                     if status.success() {
                         statuses[i] = ProcessStatus::Finished;
                     } else {
-                        statuses[i] = ProcessStatus::Failed(format!(
-                            "Process exited with code: {:?}",
-                            status.code()
-                        ));
+                        statuses[i] = ProcessStatus::Failed(status.code());
                     }
                 }
                 Ok(None) => {
@@ -331,7 +328,7 @@ pub fn check_process_status(stream_manager: ResMut<StreamManager>) {
                 }
                 Err(e) => {
                     // Error checking process status
-                    statuses[i] = ProcessStatus::Failed(format!("Error checking status: {}", e));
+                    statuses[i] = ProcessStatus::Failed(None);
                 }
             }
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,7 @@ use std::path::PathBuf;
 
 use executors::{
     discrete::execute_script,
-    streaming::{update_streams, StreamManager},
+    streaming::{check_process_status, update_streams, StreamManager},
 };
 use gym3d::{
     camera::{orbit_camera, setup_isometric_camera},
@@ -103,7 +103,13 @@ fn main() {
 
     app.add_systems(
         Update,
-        (egui_system, update_streams, update_cube_position).in_set(AppSet::Main),
+        (
+            egui_system,
+            update_streams,
+            update_cube_position,
+            check_process_status,
+        )
+            .in_set(AppSet::Main),
     )
     .run();
 }

--- a/src/panels/scripts_panel.rs
+++ b/src/panels/scripts_panel.rs
@@ -422,15 +422,15 @@ fn show_streaming_scripts(ui: &mut egui::Ui, stream_manager: &StreamManager, con
                             ui.label("Running");
                         }
                         ProcessStatus::Failed(Some(code)) => {
-                            ui.colored_label(
-                                egui::Color32::RED,
-                                format!("Terminated (code: {})", code),
-                            );
+                            ui.colored_label(egui::Color32::RED, format!("Error (code: {})", code));
                         }
                         ProcessStatus::Failed(None) => {
                             ui.colored_label(egui::Color32::RED, "Terminated (unknown)");
                         }
                         ProcessStatus::Finished => {
+                            ui.colored_label(egui::Color32::GREEN, "Finished");
+                        }
+                        ProcessStatus::Stopped => {
                             ui.label("Stopped");
                         }
                     }

--- a/src/panels/scripts_panel.rs
+++ b/src/panels/scripts_panel.rs
@@ -410,13 +410,17 @@ fn show_streaming_scripts(ui: &mut egui::Ui, stream_manager: &StreamManager, con
         ui.label("");
         ui.end_row();
 
-        if let Ok(statuses) = stream_manager.process_statuses.lock() {
+        if let Ok(processes) = stream_manager.streaming_processes.lock() {
             for (i, script) in config.scripts.iter().enumerate() {
                 if script.script_type == "streaming" {
                     ui.label(&script.path);
 
                     // Get the status for this script's process
-                    let status = statuses.get(i).cloned().unwrap_or(ProcessStatus::Finished);
+                    let status = processes
+                        .get(i)
+                        .map(|(_, status)| status.clone())
+                        .unwrap_or(ProcessStatus::Stopped);
+
                     match status {
                         ProcessStatus::Running => {
                             ui.label("Running");

--- a/src/panels/scripts_panel.rs
+++ b/src/panels/scripts_panel.rs
@@ -1,4 +1,4 @@
-use crate::executors::streaming::StreamManager;
+use crate::executors::streaming::{ProcessStatus, StreamManager};
 
 use bevy::prelude::*;
 use bevy_egui::egui;
@@ -410,17 +410,35 @@ fn show_streaming_scripts(ui: &mut egui::Ui, stream_manager: &StreamManager, con
         ui.label("");
         ui.end_row();
 
-        for script in &config.scripts {
-            if script.script_type == "streaming" {
-                ui.label(&script.path);
-                ui.label(if stream_manager.is_running() {
-                    "Running"
-                } else {
-                    "Stopped"
-                });
-                ui.label("");
-                ui.label("");
-                ui.end_row();
+        if let Ok(statuses) = stream_manager.process_statuses.lock() {
+            for (i, script) in config.scripts.iter().enumerate() {
+                if script.script_type == "streaming" {
+                    ui.label(&script.path);
+
+                    // Get the status for this script's process
+                    let status = statuses.get(i).cloned().unwrap_or(ProcessStatus::Finished);
+                    match status {
+                        ProcessStatus::Running => {
+                            ui.label("Running");
+                        }
+                        ProcessStatus::Failed(Some(code)) => {
+                            ui.colored_label(
+                                egui::Color32::RED,
+                                format!("Terminated (code: {})", code),
+                            );
+                        }
+                        ProcessStatus::Failed(None) => {
+                            ui.colored_label(egui::Color32::RED, "Terminated (unknown)");
+                        }
+                        ProcessStatus::Finished => {
+                            ui.label("Stopped");
+                        }
+                    }
+
+                    ui.label("");
+                    ui.label("");
+                    ui.end_row();
+                }
             }
         }
     }

--- a/src/panels/scripts_panel.rs
+++ b/src/panels/scripts_panel.rs
@@ -255,6 +255,7 @@ fn handle_streaming_script(
     let mut child = Command::new("python3")
         .arg(&script_path)
         .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
         .spawn()
         .expect("Failed to spawn streaming script");
 

--- a/test_apps/4_flight_replay/config.toml
+++ b/test_apps/4_flight_replay/config.toml
@@ -11,7 +11,7 @@ logo_path = "assets/logo.png"
 # Left panel configuration (new section)
 [layout.left_panel]
 enabled = true
-default_width = 0.2  # Fraction of window width
+default_width = 0.2 # Fraction of window width
 
 [[layout.left_panel.tabs]]
 id = "docs"
@@ -20,7 +20,7 @@ label = "Instructions"
 # Right panel configuration
 [layout.right_panel]
 enabled = true
-default_width = 0.2  # Fraction of window width
+default_width = 0.2 # Fraction of window width
 
 [[layout.right_panel.tabs]]
 id = "controls"
@@ -32,7 +32,7 @@ type = "line"
 title = "Streaming Data Plot"
 x_label = "Time (s)"
 y_label = "Value"
-tab = "controls"  # Assign to second tab
+tab = "controls"              # Assign to second tab
 
 # Python scripts
 
@@ -41,3 +41,7 @@ name = "Flight Replay"
 path = "flight_replay.py"
 type = "streaming"
 
+[[scripts]]
+name = "Fail Status"
+path = "fail_status.py"
+type = "streaming"

--- a/test_apps/4_flight_replay/fail_status.py
+++ b/test_apps/4_flight_replay/fail_status.py
@@ -1,0 +1,6 @@
+import time
+
+if __name__ == "__main__":
+    print("Exiting with an error for testing in 1 second")
+    time.sleep(1)
+    raise Exception("Dummy error")

--- a/test_apps/4_flight_replay/flight_replay.py
+++ b/test_apps/4_flight_replay/flight_replay.py
@@ -8,33 +8,36 @@ import os
 
 # Add scale factor constant
 LAT_LON_SCALE_FACTOR = 10_000  # Scale factor for lat/lon coordinates
-ALTITUDE_SCALE_FACTOR = 1/10  # Scale factor for altitude
+ALTITUDE_SCALE_FACTOR = 1 / 10  # Scale factor for altitude
 ALTITUDE_OFFSET = 1.0  # Offset for altitude
+
 
 def stream_data():
     print("Starting flight replay stream", flush=True)
-    
+
     # Get the directory where this script is located
     script_dir = os.path.dirname(os.path.abspath(__file__))
     # Construct the full path to the CSV file
-    csv_path = os.path.join(script_dir, 'dji_ocean_flight_filtered.csv')
-    
+    csv_path = os.path.join(script_dir, "dji_ocean_flight_filtered.csv")
+
     # Read initial app state from stdin
     app_state = json.loads(sys.stdin.read())
     print(f"Received initial app state: {app_state}", flush=True)
 
     # Read the CSV file using the full path
     df = pl.read_csv(csv_path)
-    
+
     # Calculate relative coordinates by subtracting the first position
-    initial_lat = df['OSD.latitude'][0]
-    initial_lon = df['OSD.longitude'][0]
-    
+    initial_lat = df["OSD.latitude"][0]
+    initial_lon = df["OSD.longitude"][0]
+
     # Calculate relative positions using polars expressions
-    df = df.with_columns([
-        (pl.col('OSD.latitude') - initial_lat).alias('rel_lat'),
-        (pl.col('OSD.longitude') - initial_lon).alias('rel_lon')
-    ])
+    df = df.with_columns(
+        [
+            (pl.col("OSD.latitude") - initial_lat).alias("rel_lat"),
+            (pl.col("OSD.longitude") - initial_lon).alias("rel_lon"),
+        ]
+    )
 
     context = zmq.Context()
     socket = context.socket(zmq.PUSH)
@@ -47,13 +50,14 @@ def stream_data():
         for row in df.iter_rows(named=True):
             data = {
                 "stream_id": "flight_position",
-                "timestamp": float(row['timestamps_ns']) / 1e9,  # Convert ns to seconds
-                "rel_lat": float(row['rel_lat']) * LAT_LON_SCALE_FACTOR,
-                "rel_lon": float(row['rel_lon']) * LAT_LON_SCALE_FACTOR,
-                "altitude": (float(row['OSD.height [ft]']) * ALTITUDE_SCALE_FACTOR) + ALTITUDE_OFFSET,
-                "pitch": float(row['OSD.pitch']),
-                "roll": float(row['OSD.roll']),
-                "yaw": float(row['OSD.yaw'])
+                "timestamp": float(row["timestamps_ns"]) / 1e9,  # Convert ns to seconds
+                "rel_lat": float(row["rel_lat"]) * LAT_LON_SCALE_FACTOR,
+                "rel_lon": float(row["rel_lon"]) * LAT_LON_SCALE_FACTOR,
+                "altitude": (float(row["OSD.height [ft]"]) * ALTITUDE_SCALE_FACTOR)
+                + ALTITUDE_OFFSET,
+                "pitch": float(row["OSD.pitch"]),
+                "roll": float(row["OSD.roll"]),
+                "yaw": float(row["OSD.yaw"]),
             }
             print(f"Sending data: {data}", flush=True)
             socket.send_string(json.dumps(data))
@@ -65,5 +69,8 @@ def stream_data():
         socket.close()
         context.term()
 
+
 if __name__ == "__main__":
-    stream_data()
+    print("Exiting with an error for testing")
+    raise Exception("Test error")
+    # stream_data()

--- a/test_apps/4_flight_replay/flight_replay.py
+++ b/test_apps/4_flight_replay/flight_replay.py
@@ -1,6 +1,5 @@
 import zmq
 import time
-import numpy as np
 import sys
 import json
 import polars as pl

--- a/test_apps/4_flight_replay/flight_replay.py
+++ b/test_apps/4_flight_replay/flight_replay.py
@@ -71,6 +71,6 @@ def stream_data():
 
 
 if __name__ == "__main__":
-    print("Exiting with an error for testing")
-    raise Exception("Test error")
-    # stream_data()
+    # print("Exiting with an error for testing")
+    # raise Exception("Test error")
+    stream_data()

--- a/test_apps/4_flight_replay/flight_replay.py
+++ b/test_apps/4_flight_replay/flight_replay.py
@@ -71,6 +71,4 @@ def stream_data():
 
 
 if __name__ == "__main__":
-    # print("Exiting with an error for testing")
-    # raise Exception("Test error")
     stream_data()


### PR DESCRIPTION
previously if the process finished or wasn't running at all it would still show as running in the script panel, now it shows Stopped/Running/Failed by checking the processes directly. Atm it checks very frequently, could probably debounce if we need to manage a larger number of child processes
![Screenshot 2025-01-03 at 3 47 10 PM](https://github.com/user-attachments/assets/d1de2013-fe43-4c7b-9682-b27e35de2f9c)

